### PR TITLE
abuild: -dev depends on -static by default

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1708,6 +1708,17 @@ default_dev() {
 	local i= j=
 	depends="$depends_dev"
 	pkgdesc="$pkgdesc (development files)"
+	
+	if subpackage_types_has static; then
+		for i in $subpackages; do
+			j="${i##:*}"
+			case "${j}" in
+				*-static)
+					depends_has "${j}" || depends+="${depends:+ }${j}"
+				;;
+			esac
+		done
+	fi
 
 	cd "$pkgdir" || return 0
 	local libdirs=usr/

--- a/abuild.in
+++ b/abuild.in
@@ -1711,7 +1711,7 @@ default_dev() {
 	
 	if [ -z "${NO_STATIC}" ] && subpackage_types_has static; then
 		for i in $subpackages; do
-			j="${i##:*}"
+			j="${i%%:*}"
 			case "${j}" in
 				*-static)
 					depends_has "${j}" || depends+="${depends:+ }${j}"

--- a/abuild.in
+++ b/abuild.in
@@ -1709,7 +1709,7 @@ default_dev() {
 	depends="$depends_dev"
 	pkgdesc="$pkgdesc (development files)"
 	
-	if subpackage_types_has static; then
+	if [ -z "${NO_STATIC}" ] && subpackage_types_has static; then
 		for i in $subpackages; do
 			j="${i##:*}"
 			case "${j}" in

--- a/abuild.in
+++ b/abuild.in
@@ -1730,7 +1730,7 @@ default_dev() {
 			usr/lib/qt*/mkspecs			\
 			usr/lib/cmake				\
 			$(find . -name include -type d)	\
-			$([ -n "${subpackages##*$pkgname-static*}" ] && find $libdirs \
+			$(subpackage_types_has static || find $libdirs \
 				-name '*.a' 2>/dev/null) \
 			$(find $libdirs -name '*.[cho]' \
 				-o -name '*.prl' 2>/dev/null); do

--- a/abuild.in
+++ b/abuild.in
@@ -1758,7 +1758,7 @@ dev() {
 # predefined splitfunc static
 default_static() {
 	local i=
-	depends=""
+	depends="$depends_static"
 	pkgdesc="$pkgdesc (static library)"
 
 	cd "$pkgdir" || return 0

--- a/abuild.in
+++ b/abuild.in
@@ -1719,7 +1719,7 @@ default_dev() {
 			usr/lib/qt*/mkspecs			\
 			usr/lib/cmake				\
 			$(find . -name include -type d)	\
-			$([ -z "${subpackages##*$pkgname-static*}" ] && find $libdirs \
+			$([ -n "${subpackages##*$pkgname-static*}" ] && find $libdirs \
 				-name '*.a' 2>/dev/null) \
 			$(find $libdirs -name '*.[cho]' \
 				-o -name '*.prl' 2>/dev/null); do


### PR DESCRIPTION
set `NO_STATIC` to a value to prevent `-dev` from depending on `-static`

See also https://github.com/alpinelinux/abuild/pull/72